### PR TITLE
feat(infra): use 'default' aws profile unless provided in cli 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 declare -a folders=("csharp" "java" "python" "golang" "nodejs6" "nodejs6-diff-package-size")
 
-export AWS_PROFILE=personal
+export AWS_PROFILE=${1-default}
 
 for i in `seq 1 10`;
 do


### PR DESCRIPTION
currently the profile name is hardcoded in the [build.sh](https://github.com/theburningmonk/lambda-coldstart-comparison/blob/master/build.sh#L4) file.

With this change now you could just do

```
./build.sh myAwsProfileName
```

if profileName is not provided it's going to use 'default' profile name.